### PR TITLE
F2105 cloudsqlsuperuser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+# 0.0.5 (Dec 16, 2024)
+* Added the cloudsqlsuperuser role so that the user can enable extensions, create event triggers, replication users, and create replication publications and subscriptions.
+
 # 0.0.4 (Dec 14, 2024)
 * Added support for interpolating `database_name` with `{{ NULLSTONE_STACK}}`, `{{ NULLSTONE_STACK}}`, and `{{ NULLSTONE_ENV }}`.

--- a/role.tf
+++ b/role.tf
@@ -68,3 +68,23 @@ resource "restapi_object" "default_grants" {
     restapi_object.database_owner
   ]
 }
+
+resource "restapi_object" "cloudsqlsuperuser" {
+  path         = "/roles/${local.username}/cloudsqlsuperuser"
+  id_attribute = "id"
+  object_id    = "${local.username}::${local.database_owner}::${local.database_name}"
+  force_new    = [local.username, local.database_owner, local.database_name]
+  destroy_path = "/skip"
+
+  data = jsonencode({
+    role     = local.username
+    target   = local.database_owner
+    database = local.database_name
+  })
+
+  depends_on = [
+    restapi_object.role,
+    restapi_object.database,
+    restapi_object.database_owner
+  ]
+}

--- a/role.tf
+++ b/role.tf
@@ -90,21 +90,3 @@ resource "restapi_object" "role_member" {
     restapi_object.role
   ]
 }
-  path         = "/roles/${local.username}/cloudsqlsuperuser"
-  id_attribute = "id"
-  object_id    = "${local.username}::${local.database_owner}::${local.database_name}"
-  force_new    = [local.username, local.database_owner, local.database_name]
-  destroy_path = "/skip"
-
-  data = jsonencode({
-    role     = local.username
-    target   = local.database_owner
-    database = local.database_name
-  })
-
-  depends_on = [
-    restapi_object.role,
-    restapi_object.database,
-    restapi_object.database_owner
-  ]
-}

--- a/role.tf
+++ b/role.tf
@@ -69,7 +69,27 @@ resource "restapi_object" "default_grants" {
   ]
 }
 
-resource "restapi_object" "cloudsqlsuperuser" {
+locals {
+	superuser_role = "cloudsqlsuperuser"
+}
+
+resource "restapi_object" "role_member" {
+  path         = "/roles/${local.superuser_role}/members"
+  id_attribute = "member"
+  object_id    = "${local.superuser_role}::${local.username}"
+  force_new    = [local.superuser_role, local.username]
+  destroy_path = "/skip"
+
+  data = jsonencode({
+    target      = local.superuser_role
+    member      = local.username
+    useExisting = true
+  })
+
+  depends_on = [
+    restapi_object.role
+  ]
+}
   path         = "/roles/${local.username}/cloudsqlsuperuser"
   id_attribute = "id"
   object_id    = "${local.username}::${local.database_owner}::${local.database_name}"


### PR DESCRIPTION
This PR adds the `cloudsqlsuperuser` role to the db user. This role allows the user to enable extensions, create event triggers, create replication users, and create replication publications and subscriptions.

https://cloud.google.com/sql/docs/postgres/users#superuser-restrictions-and-privileges